### PR TITLE
Version bump, refactor to use simpler Component

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   },
   "devDependencies": {
     "parcel": "^1.12.4",
-    "purescript": "^0.13.6",
-    "spago": "^0.15.2"
+    "purescript": "^0.13.8",
+    "spago": "^0.16.0"
   },
   "scripts": {
     "build": "spago build",

--- a/packages.dhall
+++ b/packages.dhall
@@ -31,28 +31,24 @@ Purpose:
     the package set's repo
 
 Syntax:
-Replace the overrides' "{=}" (an empty record) with the following idea
-The "//" or "⫽" means "merge these two records and
-  when they have the same value, use the one on the right:"
+where `entityName` is one of the following:
+- dependencies
+- repo
+- version
 -------------------------------
-let overrides =
-  { packageName =
-      upstream.packageName // { updateEntity1 = "new value", updateEntity2 = "new value" }
-  , packageName =
-      upstream.packageName // { version = "v4.0.0" }
-  , packageName =
-      upstream.packageName // { repo = "https://www.example.com/path/to/new/repo.git" }
-  }
+let upstream = --
+in  upstream
+  with packageName.entityName = "new value"
 -------------------------------
 
 Example:
 -------------------------------
-let overrides =
-  { halogen =
-      upstream.halogen // { version = "master" }
-  , halogen-vdom =
-      upstream.halogen-vdom // { version = "v4.0.0" }
-  }
+let upstream = --
+in  upstream
+  with halogen.version = "master"
+  with halogen.repo = "https://example.com/path/to/git/repo.git"
+
+  with halogen-vdom.version = "v4.0.0"
 -------------------------------
 
 ### Additions
@@ -61,37 +57,30 @@ Purpose:
 - Add packages that aren't already included in the default package set
 
 Syntax:
-Replace the additions' "{=}" (an empty record) with the following idea:
+where `<version>` is:
+- a tag (i.e. "v4.0.0")
+- a branch (i.e. "master")
+- commit hash (i.e. "701f3e44aafb1a6459281714858fadf2c4c2a977")
 -------------------------------
-let additions =
-  { package-name =
-       { dependencies =
-           [ "dependency1"
-           , "dependency2"
-           ]
-       , repo =
-           "https://example.com/path/to/git/repo.git"
-       , version =
-           "tag ('v4.0.0') or branch ('master')"
-       }
-  , package-name =
-       { dependencies =
-           [ "dependency1"
-           , "dependency2"
-           ]
-       , repo =
-           "https://example.com/path/to/git/repo.git"
-       , version =
-           "tag ('v4.0.0') or branch ('master')"
-       }
-  , etc.
-  }
+let upstream = --
+in  upstream
+  with new-package-name =
+    { dependencies =
+       [ "dependency1"
+       , "dependency2"
+       ]
+    , repo =
+       "https://example.com/path/to/git/repo.git"
+    , version =
+        "<version>"
+    }
 -------------------------------
 
 Example:
 -------------------------------
-let additions =
-  { benchotron =
+let upstream = --
+in  upstream
+  with benchotron =
       { dependencies =
           [ "arrays"
           , "exists"
@@ -113,16 +102,10 @@ let additions =
       , version =
           "v7.0.0"
       }
-  }
 -------------------------------
 -}
 
-
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.6-20200127/packages.dhall sha256:06a623f48c49ea1c7675fdf47f81ddb02ae274558e29f511efae1df99ea92fb8
+      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20200822/packages.dhall sha256:b4f151f1af4c5cb6bf5437489f4231fbdd92792deaf32971e6bcb0047b3dd1f8
 
-let overrides = {=}
-
-let additions = {=}
-
-in  upstream // overrides // additions
+in  upstream

--- a/spago.dhall
+++ b/spago.dhall
@@ -4,7 +4,12 @@ You can edit this file as you like.
 -}
 { name = "my-project"
 , dependencies =
-  [ "console", "effect", "psci-support", "react-basic-hooks" ]
+  [ "console"
+  , "effect"
+  , "psci-support"
+  , "react-basic-dom"
+  , "react-basic-hooks"
+  ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]
 }

--- a/src/Example.purs
+++ b/src/Example.purs
@@ -2,13 +2,12 @@ module Example where
 
 import Prelude
 
-import Effect (Effect)
 import React.Basic.DOM as R
 import React.Basic.Events (handler_)
-import React.Basic.Hooks (ReactComponent, component, useState, (/\))
+import React.Basic.Hooks (Component, component, useState, (/\))
 import React.Basic.Hooks as React
 
-mkExample :: Effect (ReactComponent {})
+mkExample :: Component {}
 mkExample = do
   component "Example" \_ -> React.do
     count /\ setCount <- useState 0

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -6,7 +6,6 @@ import Example (mkExample)
 import Data.Maybe (Maybe(..))
 import Effect (Effect)
 import Effect.Exception (throw)
-import React.Basic.Hooks(element)
 import React.Basic.DOM (render)
 import Web.DOM.NonElementParentNode (getElementById)
 import Web.HTML (window)
@@ -20,5 +19,4 @@ main = do
     Nothing -> throw "Container element not found."
     Just c  -> do
       example <- mkExample
-      let app = element example {}
-      render app c
+      render (example {}) c


### PR DESCRIPTION
This would bump the versions of `purescript` and `spago` as well as update the package set. This involves a breaking change since `ReactComponent` is [apparently no longer exported from `React.Basic.Hooks`](https://github.com/spicydonuts/purescript-react-basic-hooks/blob/2cfbd9471355aad731a797f0cbabc2068dfac906/src/React/Basic/Hooks.purs#L1-L45). It seems the [`Component` type simplifies things anyways](https://github.com/spicydonuts/purescript-react-basic-hooks/commit/61ce4a4bc739090bd0bdca3ce9850f1fae15f202), so I've made some minor refactors to use that as needed.

The changes to `spago.dhall` and `packages.dhall` were auto-generated by running `npx spago init` after updating the `spago` version.